### PR TITLE
edited how success and cancel page are rendered so no error is thrown

### DIFF
--- a/client/src/components/pages/Success.js
+++ b/client/src/components/pages/Success.js
@@ -1,7 +1,7 @@
 import { useMutation } from '@apollo/client';
 import { UPDATE_MEMBERSHIP } from '../../utils/mutations';
 import { UserContext } from '../UserContext';
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import '../../styles/pages.css';
 
@@ -14,32 +14,18 @@ function Success() {
     const [updateMembership] = useMutation(UPDATE_MEMBERSHIP);
 
     const handlePaidMember = async () => {
-
-
         try {
-
             // Call the UPDATE_USER mutation to update the user's paid_member status
             const { data } = await updateMembership({
                 variables: {
                     id: user.user.data._id,
                 }
             });
-
-            console.log({ data })
-
-            
-
+            // console.log({ data })
         } catch (err) {
             console.error(err);
         }
     };
-
-    handlePaidMember();
-
-    const handleClick = (page) => {
-        setPage(page);
-      }
-
 
     return (
         <div className={`success-content ${theme.greyscale ? "greyscale" : ""}`}>
@@ -56,7 +42,7 @@ function Success() {
                     <br />
                     &lt;/open source&gt; offers!
                 </p>
-                <Link to='/' className='return'>Start Job Hunting!</Link>
+                <Link to='/' className='return' onClick={handlePaidMember}>Start Job Hunting!</Link>
             </div>
         </div>
     );

--- a/client/src/styles/pages.css
+++ b/client/src/styles/pages.css
@@ -1025,8 +1025,13 @@ label {
 }
 
 .success-container, .cancel-container {
-    padding-block: 35px;
-    margin-top: 35vh;
+    position: fixed;
+    top: 0;
+    height: 100vh;
+    width: 100vw;
+    padding-block: 35vh;
+    margin-top: 0;
+    z-index: 100;
     font-family: var(--text);
     text-align: center;
     background-color: rgba(255, 255, 255, 0.7);


### PR DESCRIPTION
Guys Eli caught a bug in the success and cancel pages where the handlePaidMember is recursive and thus throwing errors, so we by passed that issue by making the button at the bottom the function trigger. We also managed to make the success and cancel text banner SO BIG and the z-index SO HIGH that users have no other choice but to click on the button instead of the navlinks below it. 

Issues that still persist at the moment are:  red pointer in the nav not updating when clicked and saved jobs not displaying in the dashboard without page refresh (which I think is related to the first issue)